### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mailserver_ci.yml
+++ b/.github/workflows/mailserver_ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: MailServer - CI Build
+permissions:
+  contents: read
 
 on:
   


### PR DESCRIPTION
Potential fix for [https://github.com/DarkFactorAS/DFMailServer/security/code-scanning/3](https://github.com/DarkFactorAS/DFMailServer/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and builds a .NET project (with no steps that require write access to the repository or other resources), the minimal permission required is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` field and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
